### PR TITLE
Add Requirements for Linux and Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pypresence


### PR DESCRIPTION
I saw that there is no requirements.txt but there is a 3rd party module `pypresence` that is not installed by default so I've create a requirements.txt.
